### PR TITLE
Removed lodash and async dependencies, making module smaller and load time faster

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -12,8 +12,6 @@
 var events = require('events');
 var fs = require('fs');
 var path = require('path');
-var _ = require('lodash');
-var async = require('async');
 var Glob = require('glob').Glob;
 var minimatch = require('minimatch');
 var Gaze, gaze;
@@ -49,6 +47,82 @@ function gaze(files, opts, done) {
   return new Gaze(files, opts, done);
 }
 
+// lodash helpers
+
+var ArrayPrototype = Array.prototype;
+var toString = Object.prototype.toString;
+var has = Object.prototype.hasOwnProperty;
+
+function defaults(obj, source) {
+  for (var prop in source) {
+    if (obj[prop] == null) {
+      obj[prop] = source[prop];
+    }
+  }
+
+  return obj;
+}
+
+function unique() {
+  var array = ArrayPrototype.concat.apply(ArrayPrototype, arguments);
+  var result = [];
+
+  for (var i = 0; i < array.length; i++) {
+    if (result.indexOf(array[i]) === -1) {
+      result.push(array[i]);
+    }
+  }
+
+  return result;
+}
+
+function union() {
+  return unique.apply(null, arguments);
+}
+
+function isString(obj) {
+  return toString.call(obj) === '[object String]';
+}
+
+function isEmpty(obj) {
+  if (obj == null) { return true; }
+  
+  if (Array.isArray(obj) || isString(obj)) { return obj.length === 0; }
+
+  for (var key in obj) {
+    if (has.call(obj, key)) { return false; }
+  }
+
+  return true;
+}
+
+// async helper
+
+function forEachSeries(arr, iterator, callback) {
+  if (!arr.length) { return callback(); }
+  
+  var completed = 0;
+
+  var iterate = function() {
+    iterator(arr[completed], function (err) {
+      if (err) {
+        callback(err);
+        callback = function() {};
+      } else {
+        completed += 1;
+        
+        if (completed === arr.length) {
+          callback(null);
+        } else {
+          iterate();
+        }
+      }
+    });
+  };
+
+  iterate();
+}
+
 // `Gaze` EventEmitter object to return in the callback
 Gaze = gaze.Gaze = __extends(function(files, opts, done) {
   var _this = this;
@@ -60,7 +134,7 @@ Gaze = gaze.Gaze = __extends(function(files, opts, done) {
   }
 
   // Default options
-  this.options = _.defaults(opts || {}, {
+  this.options = defaults(opts || {}, {
     // Tell glob to mark directories
     mark: true,
     // Interval to pass to fs.watchFile
@@ -116,7 +190,7 @@ Gaze.prototype.emit = function() {
   // Detect rename event, if added and previous deleted is in the cache
   if (e === 'added') {
     Object.keys(this._cached).forEach(function(oldFile) {
-      if (_.indexOf(_this._cached[oldFile], 'deleted') !== -1) {
+      if (_this._cached[oldFile].indexOf('deleted') !== -1) {
         args[0] = e = 'renamed';
         [].push.call(args, oldFile);
         delete _this._cached[oldFile];
@@ -128,7 +202,7 @@ Gaze.prototype.emit = function() {
   // If cached doesnt exist, create a delay before running the next
   // then emit the event
   var cache = this._cached[filepath] || [];
-  if (_.indexOf(cache, e) === -1) {
+  if (cache.indexOf(e) === -1) {
     this._objectPush(_this._cached, filepath, e);
     clearTimeout(timeoutId);
     timeoutId = setTimeout(function() {
@@ -172,9 +246,9 @@ Gaze.prototype.add = function(files, done) {
   if (typeof files === 'string') {
     files = [files];
   }
-  this._patterns = _.union(this._patterns, files);
-  async.forEachSeries(files, function(pattern, next) {
-    if (_.isEmpty(pattern)) { return; }
+  this._patterns = union(this._patterns, files);
+  forEachSeries(files, function(pattern, next) {
+    if (isEmpty(pattern)) { return; }
     _this._glob = new Glob(pattern, _this.options, function(err, files) {
       if (err) {
         _this.emit('error', err);
@@ -200,7 +274,7 @@ Gaze.prototype.remove = function(file) {
   } else {
     // is a file, find and remove
     Object.keys(this._watched).forEach(function(dir) {
-      var index = _.indexOf(_this._watched[dir], file);
+      var index = _this._watched[dir].indexOf(file);
       if (index) {
         fs.unwatchFile(file);
         delete _this._watched[dir][index];
@@ -304,9 +378,9 @@ Gaze.prototype._addToWatched = function(files) {
 // Create a `key:[]` if doesnt exist on `obj` then push or concat the `val`
 Gaze.prototype._objectPush = function(obj, key, val) {
   if (obj[key] == null) { obj[key] = []; }
-  if (_.isArray(val)) { obj[key] = obj[key].concat(val); }
+  if (Array.isArray(val)) { obj[key] = obj[key].concat(val); }
   else if (val) { obj[key].push(val); }
-  return obj[key] = _.unique(obj[key]);
+  return obj[key] = unique(obj[key]);
 };
 
 // Returns true if the file matches this._patterns
@@ -356,7 +430,7 @@ Gaze.prototype._initWatched = function(done) {
   var _this = this;
   var cwd = this.options.cwd || process.cwd();
   var curWatched = Object.keys(_this._watched);
-  async.forEachSeries(curWatched, function(dir, next) {
+  forEachSeries(curWatched, function(dir, next) {
     var files = _this._watched[dir];
     // Triggered when a watched dir has an event
     _this._watchDir(dir, function(event, dirpath) {
@@ -383,8 +457,8 @@ Gaze.prototype._initWatched = function(done) {
         var previous = _this.relative(relDir);
 
         // If file was deleted
-        _.filter(previous, function(file) {
-          return _.indexOf(current, file) < 0;
+        previous.filter(function(file) {
+          return current.indexOf(file) < 0;
         }).forEach(function(file) {
           if (!_this._isDir(file)) {
             var filepath = path.join(dir, file);
@@ -394,8 +468,8 @@ Gaze.prototype._initWatched = function(done) {
         });
 
         // If file was added
-        _.filter(current, function(file) {
-          return _.indexOf(previous, file) < 0;
+        current.filter(function(file) {
+          return previous.indexOf(file) < 0;
         }).forEach(function(file) {
           // Is it a matching pattern?
           var relFile = path.join(relDir, file);

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "test": "grunt nodeunit -v"
   },
   "dependencies": {
-    "async": "~0.1.22",
     "glob": "~3.1.14",
-    "lodash": "~0.10.0",
     "minimatch": "~0.2.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Not having to require those two modules cuts out somewhere around 20-30 ms when you call `require('gaze')`. Only a few methods were being used so they've been implemented.
