### PR TITLE
Test case for exclusions in Gaze.

### DIFF
--- a/test/exclusion_test.js
+++ b/test/exclusion_test.js
@@ -21,10 +21,15 @@ exports.exclusion = {
         watcher.close();
         test.done();
       });
+      //Write a file that shouldn't ever match a pattern, but is in the same directory as one that does.
+      fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'two.txt'), 'Will I be watched?');
+
+      //Write a file that is part of the exclusion.
       fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'nested', 'sub', 'two.js'), 'var two = true;');
-      //Give time for watcher to respond and see if it does to the excluded file.
+
+      //Give time for watcher to respond and see if it responds to either file that shouldn't be watched.
       setTimeout(function() {
-        fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'sub', 'one.js'), 'var one = true;');
+        //fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'sub', 'one.js'), 'var one = true;');
       }, 2000);
     })
   }


### PR DESCRIPTION
@shama, Testcase!

This is related to gruntjs/grunt-contrib-watch#20, will allow us to change the task to pass the unexpanded Globs to Gaze.

Assuming this is accepted, I'm pretty close to getting it fixed. I've got the exclusion test itself working, but it ends up being too greedy, and fires add events from Gaze on the .txt file.. etc. Not sure what's going on there yet.
