### PR TITLE
Removed 'var Gaze, gaze' which resulted in errors.

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -14,7 +14,6 @@ var fs = require('fs');
 var path = require('path');
 var Glob = require('glob').Glob;
 var minimatch = require('minimatch');
-var Gaze, gaze;
 
 // globals
 var delay = 10;


### PR DESCRIPTION
SyntaxError: Variable 'gaze' has already been declared
