### PR TITLE
mac filesystem timestamp resolution is 1sec

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -452,7 +452,7 @@ Gaze.prototype._initWatched = function(done) {
     setTimeout(function() {
       _this.emit('ready', _this);
       done.call(_this, null, _this);
-    }, delay + 100);
+    }, 1000);
 
   });
 };


### PR DESCRIPTION
fs.watchFile is dependent on the file mtime to fire an event.  The resolution of this time is 1 second on a mac (I don't know what it is on windows).  Updating a file faster than that will cause gaze to miss the change.
#33
