### PR TITLE
fix for Issue #41 - support for absolute paths

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -360,6 +360,12 @@ Gaze.prototype._initWatched = function(done) {
           self._internalAdd(relFile, function() {
             self.emit('added', path.join(dir, file));
           });
+
+          // Support for absolute paths
+          var absFile = fs.realpathSync(relFile);
+          self._internalAdd(absFile, function() {
+            self.emit('added', path.join(dir, file));
+          });
         });
 
       });

--- a/test/watch_test.js
+++ b/test/watch_test.js
@@ -68,6 +68,20 @@ exports.watch = {
       watcher.on('end', test.done);
     });
   },
+  addedAbsolutePath: function(test) {
+    test.expect(1);
+    gaze(path.resolve(__dirname, 'fixtures', 'sub','**/*'), function(err, watcher) {
+      watcher.on('added', function(filepath) {
+        var expected = path.relative(process.cwd(), filepath);
+        test.equal(path.join('sub', 'tmp.js'), expected);
+        watcher.close();
+      });
+      this.on('changed', function() { test.ok(false, 'changed event should not have emitted.'); });
+      this.on('deleted', function() { test.ok(false, 'deleted event should not have emitted.'); });
+      fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'sub', 'tmp.js'), 'var tmp = true;');
+      watcher.on('end', test.done);
+    });
+  },
   dontAddUnmatchedFiles: function(test) {
     test.expect(2);
     gaze('**/*.js', function(err, watcher) {


### PR DESCRIPTION
Adding 2 watchers (one relative, one absolute) is a bit redundant, but it seems to get the job done. The code in the pull request was tested via grunt and passed all tests including the addedAbsolutePath which you'll find in the pull request.

https://github.com/shama/gaze/issues/41
