### PR TITLE
fix for grunt-contrib-watch/issues/166 - track new file additions within...

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -239,6 +239,10 @@ Gaze.prototype._addToWatched = function(files) {
     var dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
     dirname = helper.markDir(dirname);
 
+    if (helper.isDir(file) && !(filepath in this._watched)) {
+      helper.objectPush(this._watched, filepath, []);
+    }
+
     if (file.slice(-1) === '/') { filepath += path.sep; }
     helper.objectPush(this._watched, path.dirname(filepath) + path.sep, filepath);
 


### PR DESCRIPTION
... newly created folders.

Even with these code changes, there's still a use case that the code does not handle. 

If I execute

```
fs.mkdirSync('new_dir');
fs.writeFileSync('new_dir/tmp.js', '');
```

the creation of tmp.js will not trigger any events. This works, however:

```
fs.mkdirSync('new_dir');
setTimeout( function () {
  fs.writeFileSync('new_dir/tmp.js', '');
}, 1000);
```

see: https://github.com/gruntjs/grunt-contrib-watch/issues/166
