### PR TITLE
Fixes #49: fix for gaze.remove to remove a single file in a directory

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -182,9 +182,9 @@ Gaze.prototype.remove = function(file) {
     // is a file, find and remove
     Object.keys(this._watched).forEach(function(dir) {
       var index = self._watched[dir].indexOf(file);
-      if (index) {
+      if (index !== -1) {
         self._unpollFile(file);
-        delete self._watched[dir][index];
+        self._watched[dir].splice(index, 1);
         return false;
       }
     });


### PR DESCRIPTION
The fix is very simple. That was a very unexpected little mistake.

Actually, there're other problems of `gaze.remove`. But I thought I should do one merge request for one issue.
