### PR TITLE
Fixing Cannot call method 'call' of undefined

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -384,7 +384,7 @@ Gaze.prototype._initWatched = function(done) {
     // delay before ready solves a lot of issues
     setTimeout(function() {
       self.emit('ready', self);
-      done.call(self, null, self);
+      (done || function(){}).call(self, null, self);
     }, delay + 100);
 
   });


### PR DESCRIPTION
Hello,

I used the _.add_ method like that:

```
watcher.add([file])
```

and I got 

```
...gaze\lib\gaze.js:387
      done.call(self, null, self);
           ^
TypeError: Cannot call method 'call' of undefined
    at null._onTimeout (D:\work\KrasimirTsonev\github\absurd\node_modules\gaze\l
ib\gaze.js:387:12)
```

_initWatched method expects a callback. If you miss that you end up with the above error. 
