### PR TITLE
Wait until all listeners are removed before finishing test

### DIFF
--- a/test/add_test.js
+++ b/test/add_test.js
@@ -46,8 +46,8 @@ exports.add = {
         test.deepEqual(watcher.relative('sub'), ['one.js', 'two.js']);
         watcher.on('changed', function(filepath) {
           test.equal('two.js', path.basename(filepath));
+          watcher.on('end', test.done);
           watcher.close();
-          test.done();
         });
         fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'sub', 'two.js'), 'var two = true;');
       });
@@ -59,8 +59,8 @@ exports.add = {
       this.add('sub/two.js');
       this.on('changed', function(filepath) {
         test.equal('two.js', path.basename(filepath));
+        watcher.on('end', test.done);
         watcher.close();
-        test.done();
       });
       setTimeout(function() {
         fs.writeFileSync(path.resolve(__dirname, 'fixtures', 'sub', 'two.js'), 'var two = true;');

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -14,16 +14,16 @@ exports.api = {
       var result = this.relative(null, true);
       test.deepEqual(result['.'], ['Project (LO)/', 'nested/', 'one.js', 'sub/']);
       test.deepEqual(result['sub/'], ['one.js', 'two.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   func: function(test) {
     test.expect(1);
     var g = gaze('**/*', function(err, watcher) {
       test.deepEqual(watcher.relative('sub', true), ['one.js', 'two.js']);
+      g.on('end', test.done);
       g.close();
-      test.done();
     });
   },
   ready: function(test) {
@@ -31,8 +31,8 @@ exports.api = {
     var g = new gaze.Gaze('**/*');
     g.on('ready', function(watcher) {
       test.deepEqual(watcher.relative('sub', true), ['one.js', 'two.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   nomatch: function(test) {

--- a/test/matching_test.js
+++ b/test/matching_test.js
@@ -32,16 +32,16 @@ exports.matching = {
       var result = this.relative(null, true);
       test.deepEqual(result['.'], ['Project (LO)/', 'nested/', 'one.js', 'sub/']);
       test.deepEqual(result['sub/'], ['one.js', 'two.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   relativeDir: function(test) {
     test.expect(1);
     gaze('**/*', function() {
       test.deepEqual(this.relative('sub', true), ['one.js', 'two.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   globArray: function(test) {
@@ -50,8 +50,8 @@ exports.matching = {
       var result = this.relative(null, true);
       test.deepEqual(sortobj(result['.']), sortobj(['one.js', 'Project (LO)/', 'nested/', 'sub/']));
       test.deepEqual(sortobj(result['sub/']), sortobj(['one.js', 'two.js']));
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   globArrayDot: function(test) {
@@ -59,8 +59,8 @@ exports.matching = {
     gaze(['./sub/*.js'], function() {
       var result = this.relative(null, true);
       test.deepEqual(result['sub/'], ['one.js', 'two.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   oddName: function(test) {
@@ -68,8 +68,8 @@ exports.matching = {
     gaze(['Project (LO)/*.js'], function() {
       var result = this.relative(null, true);
       test.deepEqual(result['Project (LO)/'], ['one.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   addedLater: function(test) {

--- a/test/relative_test.js
+++ b/test/relative_test.js
@@ -23,6 +23,7 @@ exports.relative = {
     var gaze = new Gaze('addnothingtowatch');
     gaze._addToWatched(files);
     test.deepEqual(gaze.relative('.', true), ['Project (LO)/', 'nested/', 'one.js', 'sub/']);
-    test.done();
+    gaze.on('end', test.done);
+    gaze.close();
   }
 };

--- a/test/rename_test.js
+++ b/test/rename_test.js
@@ -31,8 +31,8 @@ exports.watch = {
       watcher.on('renamed', function(newFile, oldFile) {
         test.equal(newFile, newPath);
         test.equal(oldFile, oldPath);
+        watcher.on('end', test.done);
         watcher.close();
-        test.done();
       });
       fs.renameSync(oldPath, newPath);
     });

--- a/test/safewrite_test.js
+++ b/test/safewrite_test.js
@@ -44,8 +44,8 @@ exports.safewrite = {
         if (times < 2) {
           setTimeout(simSafewrite, 1000);
         } else {
+          this.on('end', test.done);
           this.close();
-          test.done();
         }
       });
 

--- a/test/watch_test.js
+++ b/test/watch_test.js
@@ -39,8 +39,8 @@ exports.watch = {
       var result = this.relative(null, true);
       test.deepEqual(result['sub/'], ['one.js']);
       test.notDeepEqual(result['.'], ['one.js']);
+      this.on('end', test.done);
       this.close();
-      test.done();
     });
   },
   changed: function(test) {
@@ -163,7 +163,8 @@ exports.watch = {
     test.expect(1);
     gaze('non/existent/**/*', function(err, watcher) {
       test.ok(true);
-      test.done();
+      watcher.on('end', test.done);
+      watcher.close();
     });
   },
   differentCWD: function(test) {


### PR DESCRIPTION
Without this change, running just the test/add_test.js tests, Node never exits.  E.g.

```
./node_modules/grunt-contrib-nodeunit/node_modules/.bin/nodeunit test/add_test.js
```

I'm trying to test some changes and having trouble getting the tests to run properly.  I'm guessing there may be other similar problems, but this one was the clearest.
