### PR TITLE
Events emitted for paths that don't match the pattern

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -118,9 +118,12 @@ Gaze.prototype.emit = function() {
     timeoutId = setTimeout(function() {
       delete self._cached[filepath];
     }, this.options.debounceDelay);
-    // Emit the event and `all` event
-    Gaze.super_.prototype.emit.apply(self, args);
-    Gaze.super_.prototype.emit.apply(self, ['all', e].concat([].slice.call(args, 1)));
+    // Emit the event and `all` event if path matches
+    var relPath = path.relative(self.options.cwd || process.cwd(), filepath);
+    if (globule.isMatch(self._patterns, relPath, self.options)) {
+      Gaze.super_.prototype.emit.apply(self, args);
+      Gaze.super_.prototype.emit.apply(self, ['all', e].concat([].slice.call(args, 1)));
+    }
   }
 
   // Detect if new folder added to trigger for matching files within folder


### PR DESCRIPTION
The `add` event is emitted for added directories, even if they don't match the provided pattern (the test added in 80271bd8010e08903d0fe4bcf2cb1746e7f30a7c asserts this behavior).

Incidentally, this causes the ["finicky" `addedLater` test](https://github.com/shama/gaze/blob/623c7fa7b773572b4821b4ee121222d0db0ddfbd/test/matching_test.js#L90).  The test does two writes, presumably to get an `add` event followed by a `change` event.  However, there are two `add` events for the first write (one for `newfolder` and one for `newfolder/added.js`).  So the test finishes before the second write, and the `newfolder` is created after the cleanup.
