### PR TITLE
add startup benchmarks

### DIFF
--- a/benchmarks/startup.js
+++ b/benchmarks/startup.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var gaze = require('../lib/gaze');
+var async = require('async');
+var fs = require('fs');
+var rimraf = require('rimraf');
+var path = require('path');
+
+// Folder to watch
+var watchDir = path.resolve(__dirname, 'watch');
+var multiplesOf = 100;
+var max = 2000;
+var numFiles = [];
+for (var i = 0; i <= max/multiplesOf; i++) {
+  numFiles.push(i*multiplesOf);
+}
+
+var modFile = path.join(watchDir, 'test-'+numFiles+'.txt');
+
+// Helper for creating mock files
+function createFiles(num, dir) {
+  for (var i = 0; i <= num; i++) {
+    fs.writeFileSync(path.join(dir, 'test-' + i + '.txt'), String(i));
+  }
+}
+
+function teardown(){
+  if (fs.existsSync(watchDir)) {
+    rimraf.sync(watchDir);
+  }
+}
+
+function setup(num){
+  teardown();
+  fs.mkdirSync(watchDir);
+  createFiles(num, watchDir);
+}
+
+function measureStart(cb) {
+  var start = Date.now();
+  var blocked, ready, watcher;
+  // workaround #77
+  var check = function(){
+    if (ready && blocked) {
+      cb(ready, blocked, watcher);
+    }
+  };
+  gaze(watchDir+'/**/*', {maxListeners:0}, function(err) {
+    ready = Date.now()-start;
+    watcher = this;
+    check();
+  });
+  blocked = Date.now()-start;
+  check();
+}
+
+function bench(num, cb) {
+  setup(num);
+  measureStart(function(time, blocked, watcher){
+    console.log(num, time);
+    watcher.close();
+    cb();
+  });
+}
+
+console.log('numFiles startTime');
+async.eachSeries(numFiles, bench, function(){
+  cleanup();
+  console.log('done!');
+});

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "grunt-contrib-nodeunit": "~0.2.0",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-benchmark": "~0.2.0",
-    "grunt-cli": "~0.1.13"
+    "grunt-cli": "~0.1.13",
+    "async": "~0.2.10",
+    "rimraf": "~2.2.6"
   },
   "keywords": [
     "watch",


### PR DESCRIPTION
This measures the time it takes for gaze to become ready. This also measures how long gaze blocks the main thread, but I have left that number out of the output because it is usually within 1-2ms of the ready time.

Results:

```
numFiles startTime
0 117
100 320
200 901
300 1898
400 3431
500 5635
600 8425
700 11472
800 15203
900 19802
1000 25870
1100 30020
1200 35856
1300 42044
1400 50612
1500 59471
1600 68263
1700 78745
1800 91209
1900 104107
2000 118597
```

So the growth graph looks like this

![growth](https://i.cloudup.com/pwRrspOh0n-2000x2000.png)

Something is definitely off here and needs fixing. Starting a watch on 2000 files blocks the main thread for almost 2 minutes.
