### PR TITLE
Defers emitting nomatch/ready events when there is no matching files

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -15,6 +15,7 @@ var fs = require('fs');
 var path = require('path');
 var globule = require('globule');
 var helper = require('./helper');
+var setImmediate = require('timers').setImmediate;
 
 // globals
 var delay = 10;
@@ -336,9 +337,12 @@ Gaze.prototype._initWatched = function(done) {
 
   // if no matching files
   if (curWatched.length < 1) {
-    self.emit('ready', self);
-    if (done) { done.call(self, null, self); }
-    self.emit('nomatch');
+    // Defer to emitting to give a chance to attach event handlers.
+    setImmediate(function () {
+      self.emit('ready', self);
+      if (done) { done.call(self, null, self); }
+      self.emit('nomatch');
+    });
     return;
   }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -35,6 +35,15 @@ exports.api = {
       this.close();
     });
   },
+  newGazeNomatch: function(test) {
+    test.expect(1);
+    var g = new gaze.Gaze('nomatch.js');
+    g.on('nomatch', function(watcher) {
+      test.ok(true, 'nomatch was emitted.');
+      this.on('end', test.done);
+      this.close();
+    });
+  },
   nomatch: function(test) {
     test.expect(1);
     gaze('nomatch.js', function(err, watcher) {


### PR DESCRIPTION
To give a chance for clients of the alternate interface (`new Gaze`) to attach event handlers. Fixes #81
