### PR TITLE
Set min required Windows to Vista

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,6 +32,9 @@
             4506,  # no definition for inline function
             4996,  # function was declared deprecated
           ],
+          'defines': [
+            '_WIN32_WINNT=0x0600',
+          ],
         }],  # OS=="win"
         ['OS=="mac"', {
           "sources": [


### PR DESCRIPTION
The `CancelIoEx` function is only available on Win Vista+. So we have to set it.

Solves #97
