### PR TITLE
Prevent race condition (fixes #134)

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -267,8 +267,14 @@ Gaze.prototype._wasAdded = function(dir) {
     }
     helper.forEachSeries(current, function(file, next) {
       var filepath = path.join(dir, file);
-      if (!fs.existsSync(filepath)) return next();
-      var stat = fs.lstatSync(filepath);
+      var stat;
+      try {
+        stat = fs.lstatSync(filepath);
+      }
+      catch (err) {
+        if (err.code === 'ENOENT') return next();
+        throw err;
+      }
       if ((dirstat.mtime - stat.mtime) <= 0) {
         var relpath = path.relative(self.options.cwd, filepath);
         if (stat.isDirectory()) {


### PR DESCRIPTION
this fixes it, I no longer get the uncaught ENOENT error I reported in #134

but I notice there's a lot more calls to `fs.existsSync` throughout the code... might be worth trying to remove them too, for the same reason stated in the issue
