### PR TITLE
undefined is not a function

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -22,6 +22,7 @@ var watched = Object.create(null);
 var renameWaiting = null;
 var renameWaitingFile = null;
 var emitEvents = true;
+var noop = function() {};
 
 var platform = module.exports = function(file, cb) {
   if (PathWatcher == null) {
@@ -116,6 +117,7 @@ platform.tick = statpoll.tick.bind(statpoll);
 
 // Close up a single watcher
 platform.close = function(filepath, cb) {
+  cb = cb || noop;
   if (Array.isArray(watched[filepath])) {
     try {
       for (var i = 0; i < watched[filepath].length; i++) {


### PR DESCRIPTION
From: https://github.com/shama/gaze/blob/master/lib/gaze.js#L260 it is possible that there would be no callback provided as described in https://github.com/shama/gaze/blob/master/lib/platform.js#L118 . I just added a case for when there is no callback provided. I needed this fix for a project of mine. 

Other wise great work Kyle Robinson Young :)

This fix is for the following error

```
TypeError: undefined is not a function
    at Function.platform.close (/server/node/eve/node_modules/gaze/lib/platform.js:112:14)
    at Gaze._trigger (/server/node/eve/node_modules/gaze/lib/gaze.js:249:14)
    at Object.cb (/server/node/eve/node_modules/gaze/lib/platform.js:49:7)
    at /server/node/eve/node_modules/gaze/lib/statpoll.js:32:20
    at iterate (/server/node/eve/node_modules/gaze/lib/helper.js:106:5)
    at /server/node/eve/node_modules/gaze/lib/helper.js:116:11
    at /server/node/eve/node_modules/gaze/lib/statpoll.js:47:5
    at iterate (/server/node/eve/node_modules/gaze/lib/helper.js:106:5)
    at /server/node/eve/node_modules/gaze/lib/helper.js:116:11
    at /server/node/eve/node_modules/gaze/lib/statpoll.js:47:5
```
