### PR TITLE
Fix for ENOENT, no such file or directory error

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -269,6 +269,10 @@ Gaze.prototype._trigger = function(error, event, filepath, newFile) {
 // If a folder received a change event, investigate
 Gaze.prototype._wasAdded = function(dir) {
   var self = this;
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+  
   var dirstat = fs.statSync(dir);
   fs.readdir(dir, function(err, current) {
     if (err) {


### PR DESCRIPTION
Hey Kyle, thanks for the great module. I ran into one small issue. There is a 3rd party build script that when run against my project creates then immediately deletes a folder. The issue happens when I am watching the same folder with Gaze. That process seems to cause an error to be thrown.

`fs.js:18060: Uncaught Error: ENOENT, no such file or directory`

Then this status is shown immediately following the error:
`{filename} was deleted`

After digging around it seemed to be this was the line `var dirstat = fs.statSync(dir);` that was causing the issue. I added a check to make sure the folder exists before statSync is run.

Thanks!
