### PR TITLE
add support for debouncing leading event

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -43,6 +43,7 @@ function Gaze(patterns, opts, done) {
   opts = opts || {};
   opts.mark = true;
   opts.interval = opts.interval || 500;
+  opts.debounceLeading = (opts.debounceLeading == 'true')
   opts.debounceDelay = opts.debounceDelay || 500;
   opts.cwd = opts.cwd || process.cwd();
   this.options = opts;
@@ -167,15 +168,25 @@ Gaze.prototype.emit = function() {
   // If cached doesnt exist, create a delay before running the next
   // then emit the event
   var cache = this._cached[filepath] || [];
+  var options = this.options;
+  var emitEvent = function (args, e) {
+    Gaze.super_.prototype.emit.apply(self, args);
+    Gaze.super_.prototype.emit.apply(self, ['all', e].concat([].slice.call(args, 1)));
+  }
+
   if (cache.indexOf(e) === -1) {
     helper.objectPush(self._cached, filepath, e);
     clearTimeout(this._timeoutId);
     this._timeoutId = setTimeout(function() {
+      if (options.debounceLeading) {
+        emitEvent(args, e);
+      }
       delete self._cached[filepath];
     }, this.options.debounceDelay);
     // Emit the event and `all` event
-    Gaze.super_.prototype.emit.apply(self, args);
-    Gaze.super_.prototype.emit.apply(self, ['all', e].concat([].slice.call(args, 1)));
+    if (!this.options.debounceLeading) {
+      emitEvent(args, e);
+    }
   }
 
   // Detect if new folder added to trigger for matching files within folder


### PR DESCRIPTION
`debounceDelay` only applies to _subsequent_ events, not the initial event, which is always immediately fired.  In the case that you want to wait for completion of initial activity on a file (e.g. sequential auto-saves in an editor), it's beneficial to debounce the leading event.  This patch introduces `debounceLeading` which does just that - the leading event will not be fired immediately, but at the end of the debounce timeout.

Related issue is: https://github.com/shama/gaze/pull/142

Debouncing the leading event (essentially forcing trailing event emission) coincidentally solve the above problem as well, however there is probably a more general way to solve both issues (see Underscore semantics of [debounce](http://underscorejs.org/#debounce) and [throttle](http://underscorejs.org/#throttle) with leading/trailing).

This patch has not been tested on master, but [identical patch](https://github.com/ahamid/gaze/tree/debounceLeading-0.5.1) passes (existing) tests on 0.5.1.
