### PR TITLE
:zap: Upgrade globule dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt nodeunit -v"
   },
   "dependencies": {
-    "globule": "~0.1.0"
+    "globule": "~0.2.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
As globule `0.1.0` require a `1.x` deprecated release of lodash.