### PR TITLE
bump dependecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,16 +23,16 @@
     "test": "semistandard && grunt nodeunit -v"
   },
   "dependencies": {
-    "globule": "^0.2.0"
+    "globule": "^1.0.0"
   },
   "devDependencies": {
     "async": "^1.5.2",
-    "grunt": "^0.4.5",
-    "grunt-benchmark": "~0.2.0",
-    "grunt-cli": "~0.1.13",
+    "grunt": "^1.0.1",
+    "grunt-benchmark": "^0.3.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-nodeunit": "^1.0.0",
-    "rimraf": "^2.5.0",
+    "rimraf": "^2.5.2",
     "semistandard": "^7.0.5"
   },
   "keywords": [


### PR DESCRIPTION
Specially because globule 0.x using lodash 1.x and trowing warning on install.
Tests passing.