### PR TITLE
Add error handler for FSWatcher

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -297,6 +297,10 @@ Gaze.prototype._watchDir = function (dir, done) {
         }
       }, delay + 100);
     });
+
+    this._watchers[dir].on('error', function (err) {
+      self._handleError(err);
+    });
   } catch (err) {
     return this._handleError(err);
   }


### PR DESCRIPTION
In case FSWatcher raises the error, gaze does not handle it and the process crashes.
Add `on('error')` handler and raise gaze's error event in such cases.

Steps to reproduce:
1) Use Windows
2) Add gaze watcher on a directory
3) Add new dir in your watched dir.
4) Removed the new dir.
EPERM error is raised.