### PR TITLE
Fixes #214 - Gaze.prototype._addToWatched repeating readDir of same d…

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -257,26 +257,27 @@ Gaze.prototype._addToWatched = function (files) {
   for (var i = 0; i < files.length; i++) {
     var file = files[i];
     var filepath = path.resolve(this.options.cwd, file);
+    var isDir = helper.isDir(file);
 
-    var dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
+    var dirname = isDir ? filepath : path.dirname(filepath);
     dirname = helper.markDir(dirname);
 
     // If a new dir is added
-    if (helper.isDir(file) && !(filepath in this._watched)) {
-      helper.objectPush(this._watched, filepath, []);
+    if (!(dirname in this._watched)) {
+        helper.objectPush(this._watched, dirname, []);
+
+        // add folders into the mix
+        var readdir = fs.readdirSync(dirname);
+        for (var j = 0; j < readdir.length; j++) {
+          var dirfile = path.join(dirname, readdir[j]);
+          if (fs.lstatSync(dirfile).isDirectory()) {
+            helper.objectPush(this._watched, dirname, dirfile + path.sep);
+          }
+        }
     }
 
     if (file.slice(-1) === '/') { filepath += path.sep; }
     helper.objectPush(this._watched, path.dirname(filepath) + path.sep, filepath);
-
-    // add folders into the mix
-    var readdir = fs.readdirSync(dirname);
-    for (var j = 0; j < readdir.length; j++) {
-      var dirfile = path.join(dirname, readdir[j]);
-      if (fs.lstatSync(dirfile).isDirectory()) {
-        helper.objectPush(this._watched, dirname, dirfile + path.sep);
-      }
-    }
   }
   return this;
 };

--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -264,16 +264,16 @@ Gaze.prototype._addToWatched = function (files) {
 
     // If a new dir is added
     if (!(dirname in this._watched)) {
-        helper.objectPush(this._watched, dirname, []);
+      helper.objectPush(this._watched, dirname, []);
 
-        // add folders into the mix
-        var readdir = fs.readdirSync(dirname);
-        for (var j = 0; j < readdir.length; j++) {
-          var dirfile = path.join(dirname, readdir[j]);
-          if (fs.lstatSync(dirfile).isDirectory()) {
-            helper.objectPush(this._watched, dirname, dirfile + path.sep);
-          }
+      // add folders into the mix
+      var readdir = fs.readdirSync(dirname);
+      for (var j = 0; j < readdir.length; j++) {
+        var dirfile = path.join(dirname, readdir[j]);
+        if (fs.lstatSync(dirfile).isDirectory()) {
+          helper.objectPush(this._watched, dirname, dirfile + path.sep);
         }
+      }
     }
 
     if (file.slice(-1) === '/') { filepath += path.sep; }

--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -257,10 +257,7 @@ Gaze.prototype._addToWatched = function (files) {
   for (var i = 0; i < files.length; i++) {
     var file = files[i];
     var filepath = path.resolve(this.options.cwd, file);
-    var isDir = helper.isDir(file);
-
-    var dirname = isDir ? filepath : path.dirname(filepath);
-    dirname = helper.markDir(dirname);
+    var dirname = helper.markDir(path.dirname(filepath));
 
     // If a new dir is added
     if (!(dirname in this._watched)) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -13,16 +13,16 @@ helper.isDir = function isDir (dir) {
 
 // Create a `key:[]` if doesnt exist on `obj` then push or concat the `val`
 helper.objectPush = function objectPush (obj, key, val) {
-  if (obj[key] == null) {
-    obj[key] = [];
+  var arr = obj[key];
+  if (arr == null) {
+    obj[key] = arr = [];
   }
   if (Array.isArray(val)) {
-    obj[key] = obj[key].concat(val);
-  } else if (val) {
-    obj[key].push(val);
+    obj[key] = arr = helper.unique(arr, val);
+  } else if (val && arr.indexOf(val) === -1) {
+    arr.push(val);
   }
-  obj[key] = helper.unique(obj[key]);
-  return obj[key];
+  return arr;
 };
 
 // Ensures the dir is marked with path.sep

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -14,7 +14,13 @@ exports.add = {
     done();
   },
   addToWatched: function (test) {
-    test.expect(1);
+    test.expect(2);
+    var oldreaddirSync = fs.readdirSync;
+    var readdirCount = 0;
+    fs.readdirSync = function() {
+      readdirCount++;
+      return oldreaddirSync.apply(this, arguments);
+    };
     var files = [
       'Project (LO)/',
       'Project (LO)/one.js',
@@ -31,10 +37,14 @@ exports.add = {
       'nested/': ['sub/', 'sub2/', 'one.js', 'three.js'],
       'nested/sub/': ['two.js'],
     };
+
     var gaze = new Gaze('addnothingtowatch');
     gaze._addToWatched(files);
     var result = gaze.relative(null, true);
     test.deepEqual(sortobj(result), sortobj(expected));
+    test.strictEqual(readdirCount, 4);
+
+    fs.readdirSync = oldreaddirSync;
     gaze.on('end', test.done);
     gaze.close();
   },


### PR DESCRIPTION
Hi,

I dug into this problem to solve performance issue with watching large folders. @smithwib seems to be correct with a small change in the _if_ statement. I added a test case to check _readdirSync_ call count. With the fix number of directory listings reduced from 8 to 4 in the _addToWatched_ test.