### PR TITLE
Fixes #221

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -256,27 +256,27 @@ Gaze.prototype.relative = function (dir, unixify) {
 Gaze.prototype._addToWatched = function (files) {
   for (var i = 0; i < files.length; i++) {
     var file = files[i];
-    var filepath = path.resolve(this.options.cwd, file);
+    var filepath = helper.resolve(this.options.cwd, file);
+    var isDir = helper.isDir(file);
 
-    var dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
+    var dirname = isDir ? filepath : path.dirname(filepath);
     dirname = helper.markDir(dirname);
 
     // If a new dir is added
-    if (helper.isDir(file) && !(filepath in this._watched)) {
-      helper.objectPush(this._watched, filepath, []);
-    }
+    if (!(dirname in this._watched)) {
+      helper.objectPush(this._watched, dirname, []);
 
-    if (file.slice(-1) === '/') { filepath += path.sep; }
-    helper.objectPush(this._watched, path.dirname(filepath) + path.sep, filepath);
-
-    // add folders into the mix
-    var readdir = fs.readdirSync(dirname);
-    for (var j = 0; j < readdir.length; j++) {
-      var dirfile = path.join(dirname, readdir[j]);
-      if (fs.lstatSync(dirfile).isDirectory()) {
-        helper.objectPush(this._watched, dirname, dirfile + path.sep);
+      // add folders into the mix
+      var readdir = fs.readdirSync(dirname);
+      for (var j = 0; j < readdir.length; j++) {
+        var dirfile = path.join(dirname, readdir[j]);
+        if (fs.lstatSync(dirfile).isDirectory()) {
+          helper.objectPush(this._watched, dirname, dirfile + path.sep);
+        }
       }
     }
+
+    helper.objectPush(this._watched, helper.markDir(path.dirname(filepath)), filepath);
   }
   return this;
 };

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -8,28 +8,37 @@ helper.isDir = function isDir (dir) {
   if (typeof dir !== 'string') {
     return false;
   }
-  return (dir.slice(-(path.sep.length)) === path.sep);
+  var lastChar = dir.slice(-1);
+  return lastChar === '/' || lastChar === '\\';
+};
+
+
+// Platform-consistent path.resolve implementation
+helper.resolve = function resolve(folder, file) {
+  var result = path.resolve(folder, file);
+  if(helper.isDir(file) && !helper.isDir(result)) {
+    result += path.sep;
+  }
+  return result;
 };
 
 // Create a `key:[]` if doesnt exist on `obj` then push or concat the `val`
 helper.objectPush = function objectPush (obj, key, val) {
-  if (obj[key] == null) {
-    obj[key] = [];
+  var arr = obj[key];
+  if (arr == null) {
+    obj[key] = arr = [];
   }
   if (Array.isArray(val)) {
-    obj[key] = obj[key].concat(val);
-  } else if (val) {
-    obj[key].push(val);
+    obj[key] = arr = helper.unique(arr, val);
+  } else if (val && arr.indexOf(val) === -1) {
+    arr.push(val);
   }
-  obj[key] = helper.unique(obj[key]);
-  return obj[key];
+  return arr;
 };
 
 // Ensures the dir is marked with path.sep
 helper.markDir = function markDir (dir) {
-  if (typeof dir === 'string' &&
-    dir.slice(-(path.sep.length)) !== path.sep &&
-    dir !== '.') {
+  if (typeof dir === 'string' && !helper.isDir(dir) && dir !== '.') {
     dir += path.sep;
   }
   return dir;

--- a/test/add_test.js
+++ b/test/add_test.js
@@ -14,7 +14,13 @@ exports.add = {
     done();
   },
   addToWatched: function (test) {
-    test.expect(1);
+    test.expect(2);
+    var oldreaddirSync = fs.readdirSync;
+    var readdirCount = 0;
+    fs.readdirSync = function() {
+      readdirCount++;
+      return oldreaddirSync.apply(this, arguments);
+    };
     var files = [
       'Project (LO)/',
       'Project (LO)/one.js',
@@ -27,14 +33,18 @@ exports.add = {
     ];
     var expected = {
       'Project (LO)/': ['one.js'],
-      '.': ['Project (LO)/', 'nested/', 'one.js', 'sub/'],
+      '.': ['Project (LO)/', 'nested/', 'one.js'],
       'nested/': ['sub/', 'sub2/', 'one.js', 'three.js'],
       'nested/sub/': ['two.js'],
     };
+
     var gaze = new Gaze('addnothingtowatch');
     gaze._addToWatched(files);
     var result = gaze.relative(null, true);
     test.deepEqual(sortobj(result), sortobj(expected));
+    test.strictEqual(readdirCount, 3);
+
+    fs.readdirSync = oldreaddirSync;
     gaze.on('end', test.done);
     gaze.close();
   },

--- a/test/relative_test.js
+++ b/test/relative_test.js
@@ -23,7 +23,7 @@ exports.relative = {
     ];
     var gaze = new Gaze('addnothingtowatch');
     gaze._addToWatched(files);
-    helper.deepEqual(test, gaze.relative('.', true), ['Project (LO)/', 'nested/', 'one.js', 'sub/']);
+    helper.deepEqual(test, gaze.relative('.', true), ['Project (LO)/', 'nested/', 'one.js']);
     gaze.on('end', test.done);
     gaze.close();
   }


### PR DESCRIPTION
Please note one test is changed because I doubt it's correct.  This line bothers me:
`var expected = { '.': ['Project (LO)/', 'nested/', 'one.js', 'sub/'], };`

The problem I see here is that we didn't add sub dir into the watch list. The test adds folders Project (LO) and nested only.

This may have unpleasant side-effects. For example, gaze is used in metalsmith-watch library. Metalsmith is a static website generator written in Node.JS. Common folder structure is

```
root
src // pages
build // ready website
node_modules
```

You configure to watch for changes in src folder and gaze also starts monitoring node_modules folder as well. I believe this is not expected behavior, so I fixed the test.