### PR TITLE
fix some  performance issues

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -254,6 +254,8 @@ Gaze.prototype.relative = function (dir, unixify) {
 
 // Adds files and dirs to watched
 Gaze.prototype._addToWatched = function (files) {
+  var dirs = [];
+
   for (var i = 0; i < files.length; i++) {
     var file = files[i];
     var filepath = path.resolve(this.options.cwd, file);
@@ -269,6 +271,13 @@ Gaze.prototype._addToWatched = function (files) {
     if (file.slice(-1) === '/') { filepath += path.sep; }
     helper.objectPush(this._watched, path.dirname(filepath) + path.sep, filepath);
 
+    dirs.push(dirname);
+  }
+
+  dirs = helper.unique(dirs);
+
+  for (var k = 0; k < dirs.length; k++) {
+    dirname = dirs[k];
     // add folders into the mix
     var readdir = fs.readdirSync(dirname);
     for (var j = 0; j < readdir.length; j++) {
@@ -278,6 +287,7 @@ Gaze.prototype._addToWatched = function (files) {
       }
     }
   }
+
   return this;
 };
 


### PR DESCRIPTION
I use glob to match some files, these files are saving in same folder, the following code will be executed more than once, because dirname is same, it make performance issues, the code at gaze.js line 289 in _addToWatched function. 

    var readdir = fs.readdirSync(dirname);

    for (var j = 0; j < readdir.length; j++) {

      var dirfile = path.join(dirname, readdir[j]);

      if (fs.lstatSync(dirfile).isDirectory()) {

        helper.objectPush(this._watched, dirname, dirfile + path.sep);
      }
    }