### PR TITLE
Fixes race condition with watchDir

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -284,6 +284,12 @@ Gaze.prototype._addToWatched = function (files) {
 Gaze.prototype._watchDir = function (dir, done) {
   var self = this;
   var timeoutId;
+
+  // race condition. Ensure that this directory still exists before watching it.
+  if (!fs.existsSync(dir)) {
+    return this;
+  }
+
   try {
     this._watchers[dir] = fs.watch(dir, function (event) {
       // race condition. Let's give the fs a little time to settle down. so we


### PR DESCRIPTION
I have a script that is actively deleting some of the directories being watched, this was causing gaze to fall over with `ENOENT` exception.

This PR addresses this issue.