### PR TITLE
update code for ES2015+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Install the module with: `npm install gaze` or place into your `package.json`
 and run `npm install`.
 
 ```javascript
-var gaze = require('gaze');
+const gaze = require('gaze');
 
 // Watch all .js files/dirs in process.cwd()
 gaze('**/*.js', (err, watcher) => {
   // Files have all started watching
 
   // Get all watched files
-  var watched = watcher.watched();
+  const watched = watcher.watched();
 
   // On file changed
   watcher.on('changed', filepath => {
@@ -42,7 +42,7 @@ gaze('**/*.js', (err, watcher) => {
   });
 
   // Get watched files with relative paths
-  var files = watcher.relative();
+  const files = watcher.relative();
 });
 
 // Also accepts an array of patterns
@@ -55,9 +55,9 @@ gaze(['stylesheets/*.css', 'images/**/*.png'], () => {
 ### Alternate Interface
 
 ```javascript
-var Gaze = require('gaze').Gaze;
+const {Gaze} = require('gaze');
 
-var gaze = new Gaze('**/*');
+const gaze = new Gaze('**/*');
 
 // Files have all started watching
 gaze.on('ready', watcher => { });
@@ -76,7 +76,7 @@ gaze('**/*', (error, watcher) => {
 });
 
 // Or with the alternative interface
-var gaze = new Gaze();
+const gaze = new Gaze();
 gaze.on('error', error => {
   // Handle error here
 });
@@ -103,8 +103,8 @@ information on glob patterns.
 Create a `Gaze` object by instancing the `gaze.Gaze` class.
 
 ```javascript
-var Gaze = require('gaze').Gaze;
-var gaze = new Gaze(pattern, options, callback);
+const Gaze = require('gaze').Gaze;
+const gaze = new Gaze(pattern, options, callback);
 ```
 
 #### Properties

--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -9,26 +9,25 @@
 'use strict';
 
 // libs
-var util = require('util');
-var EE = require('events').EventEmitter;
-var fs = require('fs');
-var path = require('path');
-var globule = require('globule');
-var helper = require('./helper');
+const util = require('util');
+const EE = require('events').EventEmitter;
+const fs = require('fs');
+const path = require('path');
+const globule = require('globule');
+const helper = require('./helper');
 
 // shim setImmediate for node v0.8
-var setImmediate = require('timers').setImmediate;
+const setImmediate = require('timers').setImmediate;
 if (typeof setImmediate !== 'function') {
   setImmediate = process.nextTick;
 }
 
 // globals
-var delay = 10;
+const delay = 10;
 
 // `Gaze` EventEmitter object to return in the callback
 function Gaze (patterns, opts, done) {
-  var self = this;
-  EE.call(self);
+  EE.call(this);
 
   // If second arg is the callback
   if (typeof opts === 'function') {
@@ -45,7 +44,7 @@ function Gaze (patterns, opts, done) {
   this.options = opts;
 
   // Default done callback
-  done = done || function () {};
+  done = done || () => {};
 
   // Remember our watched dir:files
   this._watched = Object.create(null);
@@ -75,7 +74,7 @@ function Gaze (patterns, opts, done) {
   }
 
   // keep the process alive
-  this._keepalive = setInterval(function () {}, 200);
+  this._keepalive = setInterval(() => {}, 200);
 
   return this;
 }
@@ -90,26 +89,25 @@ module.exports.Gaze = Gaze;
 // Override the emit function to emit `all` events
 // and debounce on duplicate events per file
 Gaze.prototype.emit = function () {
-  var self = this;
-  var args = arguments;
+  let args = arguments;
 
-  var e = args[0];
-  var filepath = args[1];
-  var timeoutId;
+  const e = args[0];
+  const filepath = args[1];
+  let timeoutId;
 
   // If not added/deleted/changed/renamed then just emit the event
   if (e.slice(-2) !== 'ed') {
-    Gaze.super_.prototype.emit.apply(self, args);
+    Gaze.super_.prototype.emit.apply(this, args);
     return this;
   }
 
   // Detect rename event, if added and previous deleted is in the cache
   if (e === 'added') {
-    Object.keys(this._cached).forEach(function (oldFile) {
-      if (self._cached[oldFile].indexOf('deleted') !== -1) {
+    Object.keys(this._cached).forEach( oldFile => {
+      if (this._cached[oldFile].indexOf('deleted') !== -1) {
         args[0] = e = 'renamed';
         [].push.call(args, oldFile);
-        delete self._cached[oldFile];
+        delete this._cached[oldFile];
         return false;
       }
     });
@@ -117,16 +115,16 @@ Gaze.prototype.emit = function () {
 
   // If cached doesnt exist, create a delay before running the next
   // then emit the event
-  var cache = this._cached[filepath] || [];
+  const cache = this._cached[filepath] || [];
   if (cache.indexOf(e) === -1) {
-    helper.objectPush(self._cached, filepath, e);
+    helper.objectPush(this._cached, filepath, e);
     clearTimeout(timeoutId);
-    timeoutId = setTimeout(function () {
-      delete self._cached[filepath];
+    timeoutId = setTimeout(() => {
+      delete this._cached[filepath];
     }, this.options.debounceDelay);
     // Emit the event and `all` event
-    Gaze.super_.prototype.emit.apply(self, args);
-    Gaze.super_.prototype.emit.apply(self, ['all', e].concat([].slice.call(args, 1)));
+    Gaze.super_.prototype.emit.apply(this, args);
+    Gaze.super_.prototype.emit.apply(this, ['all', e].concat([].slice.call(args, 1)));
   }
 
   // Detect if new folder added to trigger for matching files within folder
@@ -135,7 +133,7 @@ Gaze.prototype.emit = function () {
       // It's possible that between `isDir` and `readdirSync()` calls the `filepath`
       // gets removed, which will result in `ENOENT` exception
 
-      var files;
+      let files;
 
       try {
         files = fs.readdirSync(filepath);
@@ -148,12 +146,12 @@ Gaze.prototype.emit = function () {
         files = [];
       }
 
-      files.map(function (file) {
+      files.map(file => {
         return path.join(filepath, file);
-      }).filter(function (file) {
-        return globule.isMatch(self._patterns, file, self.options);
-      }).forEach(function (file) {
-        self.emit('added', file);
+      }).filter(file => {
+        return globule.isMatch(this._patterns, file, this.options);
+      }).forEach(file => {
+        this.emit('added', file);
       });
     }
   }
@@ -163,23 +161,22 @@ Gaze.prototype.emit = function () {
 
 // Close watchers
 Gaze.prototype.close = function (_reset) {
-  var self = this;
-  Object.keys(self._watchers).forEach(function (file) {
-    self._watchers[file].close();
+  Object.keys(this._watchers).forEach(file => {
+    this._watchers[file].close();
   });
-  self._watchers = Object.create(null);
-  Object.keys(this._watched).forEach(function (dir) {
-    self._unpollDir(dir);
+  this._watchers = Object.create(null);
+  Object.keys(this._watched).forEach(dir => {
+    this._unpollDir(dir);
   });
   if (_reset !== false) {
-    self._watched = Object.create(null);
-    setTimeout(function () {
-      self.emit('end');
-      self.removeAllListeners();
-      clearInterval(self._keepalive);
+    this._watched = Object.create(null);
+    setTimeout(() => {
+      this.emit('end');
+      this.removeAllListeners();
+      clearInterval(this._keepalive);
     }, delay + 100);
   }
-  return self;
+  return this;
 };
 
 // Add file patterns to be watched
@@ -194,7 +191,7 @@ Gaze.prototype.add = function (files, done) {
 
 // Dont increment patterns and dont call done if nothing added
 Gaze.prototype._internalAdd = function (file, done) {
-  var files = [];
+  let files = [];
   if (helper.isDir(file)) {
     files = [helper.markDir(file)].concat(globule.find(this._patterns, this.options));
   } else {
@@ -211,18 +208,17 @@ Gaze.prototype._internalAdd = function (file, done) {
 
 // Remove file/dir from `watched`
 Gaze.prototype.remove = function (file) {
-  var self = this;
   if (this._watched[file]) {
     // is dir, remove all files
     this._unpollDir(file);
     delete this._watched[file];
   } else {
     // is a file, find and remove
-    Object.keys(this._watched).forEach(function (dir) {
-      var index = self._watched[dir].indexOf(file);
+    Object.keys(this._watched).forEach(dir => {
+      const index = this._watched[dir].indexOf(file);
       if (index !== -1) {
-        self._unpollFile(file);
-        self._watched[dir].splice(index, 1);
+        this._unpollFile(file);
+        this._watched[dir].splice(index, 1);
         return false;
       }
     });
@@ -240,18 +236,17 @@ Gaze.prototype.watched = function () {
 
 // Returns `watched` files with relative paths to process.cwd()
 Gaze.prototype.relative = function (dir, unixify) {
-  var self = this;
-  var relative = Object.create(null);
-  var relDir, relFile, unixRelDir;
-  var cwd = this.options.cwd || process.cwd();
+  let relative = Object.create(null);
+  let relDir, relFile, unixRelDir;
+  const cwd = this.options.cwd || process.cwd();
   if (dir === '') { dir = '.'; }
   dir = helper.markDir(dir);
   unixify = unixify || false;
-  Object.keys(this._watched).forEach(function (dir) {
+  Object.keys(this._watched).forEach(dir => {
     relDir = path.relative(cwd, dir) + path.sep;
     if (relDir === path.sep) { relDir = '.'; }
     unixRelDir = unixify ? helper.unixifyPathSep(relDir) : relDir;
-    relative[unixRelDir] = self._watched[dir].map(function (file) {
+    relative[unixRelDir] = this._watched[dir].map(file => {
       relFile = path.relative(path.join(cwd, relDir) || '', file || '');
       if (helper.isDir(file)) {
         relFile = helper.markDir(relFile);
@@ -270,13 +265,13 @@ Gaze.prototype.relative = function (dir, unixify) {
 
 // Adds files and dirs to watched
 Gaze.prototype._addToWatched = function (files) {
-  var dirs = [];
+  let dirs = [];
 
-  for (var i = 0; i < files.length; i++) {
-    var file = files[i];
-    var filepath = path.resolve(this.options.cwd, file);
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    const filepath = path.resolve(this.options.cwd, file);
 
-    var dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
+    let dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
     dirname = helper.markDir(dirname);
 
     // If a new dir is added
@@ -292,12 +287,12 @@ Gaze.prototype._addToWatched = function (files) {
 
   dirs = helper.unique(dirs);
 
-  for (var k = 0; k < dirs.length; k++) {
+  for (let k = 0; k < dirs.length; k++) {
     dirname = dirs[k];
     // add folders into the mix
-    var readdir = fs.readdirSync(dirname);
-    for (var j = 0; j < readdir.length; j++) {
-      var dirfile = path.join(dirname, readdir[j]);
+    const readdir = fs.readdirSync(dirname);
+    for (let j = 0; j < readdir.length; j++) {
+      const dirfile = path.join(dirname, readdir[j]);
       if (fs.lstatSync(dirfile).isDirectory()) {
         helper.objectPush(this._watched, dirname, dirfile + path.sep);
       }
@@ -308,24 +303,23 @@ Gaze.prototype._addToWatched = function (files) {
 };
 
 Gaze.prototype._watchDir = function (dir, done) {
-  var self = this;
-  var timeoutId;
+  let timeoutId;
   try {
-    this._watchers[dir] = fs.watch(dir, function (event) {
+    this._watchers[dir] = fs.watch(dir, event => {
       // race condition. Let's give the fs a little time to settle down. so we
       // don't fire events on non existent files.
       clearTimeout(timeoutId);
-      timeoutId = setTimeout(function () {
+      timeoutId = setTimeout(() => {
         // race condition. Ensure that this directory is still being watched
         // before continuing.
-        if ((dir in self._watchers) && fs.existsSync(dir)) {
+        if ((dir in this._watchers) && fs.existsSync(dir)) {
           done(null, dir);
         }
       }, delay + 100);
     });
 
-    this._watchers[dir].on('error', function (err) {
-      self._handleError(err);
+    this._watchers[dir].on('error', err => {
+      this._handleError(err);
     });
   } catch (err) {
     return this._handleError(err);
@@ -343,15 +337,15 @@ Gaze.prototype._unpollFile = function (file) {
 
 Gaze.prototype._unpollDir = function (dir) {
   this._unpollFile(dir);
-  for (var i = 0; i < this._watched[dir].length; i++) {
+  for (let i = 0; i < this._watched[dir].length; i++) {
     this._unpollFile(this._watched[dir][i]);
   }
 };
 
 Gaze.prototype._pollFile = function (file, done) {
-  var opts = { persistent: true, interval: this.options.interval };
+  const opts = { persistent: true, interval: this.options.interval };
   if (!this._pollers[file]) {
-    this._pollers[file] = function (curr, prev) {
+    this._pollers[file] = (curr, prev) => {
       done(null, file);
     };
     try {
@@ -365,36 +359,35 @@ Gaze.prototype._pollFile = function (file, done) {
 
 // Initialize the actual watch on `watched` files
 Gaze.prototype._initWatched = function (done) {
-  var self = this;
-  var cwd = this.options.cwd || process.cwd();
-  var curWatched = Object.keys(self._watched);
+  const cwd = this.options.cwd || process.cwd();
+  let curWatched = Object.keys(this._watched);
 
   // if no matching files
   if (curWatched.length < 1) {
     // Defer to emitting to give a chance to attach event handlers.
-    setImmediate(function () {
-      self.emit('ready', self);
-      if (done) { done.call(self, null, self); }
-      self.emit('nomatch');
+    setImmediate(() => {
+      this.emit('ready', this);
+      if (done) { done.call(this, null, this); }
+      this.emit('nomatch');
     });
     return;
   }
 
-  helper.forEachSeries(curWatched, function (dir, next) {
+  helper.forEachSeries(curWatched, (dir, next) => {
     dir = dir || '';
-    var files = self._watched[dir];
+    let files = this._watched[dir];
     // Triggered when a watched dir has an event
-    self._watchDir(dir, function (event, dirpath) {
-      var relDir = cwd === dir ? '.' : path.relative(cwd, dir);
+    this._watchDir(dir, (event, dirpath) => {
+      let relDir = cwd === dir ? '.' : path.relative(cwd, dir);
       relDir = relDir || '';
 
-      fs.readdir(dirpath, function (err, current) {
-        if (err) { return self.emit('error', err); }
+      fs.readdir(dirpath, (err, current) => {
+        if (err) { return this.emit('error', err); }
         if (!current) { return; }
 
         try {
           // append path.sep to directories so they match previous.
-          current = current.map(function (curPath) {
+          current = current.map(curPath => {
             if (fs.existsSync(path.join(dir, curPath)) && fs.lstatSync(path.join(dir, curPath)).isDirectory()) {
               return curPath + path.sep;
             } else {
@@ -406,56 +399,56 @@ Gaze.prototype._initWatched = function (done) {
         }
 
         // Get watched files for this dir
-        var previous = self.relative(relDir);
+        const previous = this.relative(relDir);
 
         // If file was deleted
-        previous.filter(function (file) {
+        previous.filter(file => {
           return current.indexOf(file) < 0;
-        }).forEach(function (file) {
+        }).forEach(file => {
           if (!helper.isDir(file)) {
-            var filepath = path.join(dir, file);
-            self.remove(filepath);
-            self.emit('deleted', filepath);
+            const filepath = path.join(dir, file);
+            this.remove(filepath);
+            this.emit('deleted', filepath);
           }
         });
 
         // If file was added
-        current.filter(function (file) {
+        current.filter(file => {
           return previous.indexOf(file) < 0;
-        }).forEach(function (file) {
+        }).forEach(file => {
           // Is it a matching pattern?
-          var relFile = path.join(relDir, file);
+          const relFile = path.join(relDir, file);
           // Add to watch then emit event
-          self._internalAdd(relFile, function () {
-            self.emit('added', path.join(dir, file));
+          this._internalAdd(relFile, () => {
+            this.emit('added', path.join(dir, file));
           });
         });
       });
     });
 
     // Watch for change/rename events on files
-    files.forEach(function (file) {
+    files.forEach(file => {
       if (helper.isDir(file)) { return; }
-      self._pollFile(file, function (err, filepath) {
+      this._pollFile(file, (err, filepath) => {
         if (err) {
-          self.emit('error', err);
+          this.emit('error', err);
           return;
         }
         // Only emit changed if the file still exists
         // Prevents changed/deleted duplicate events
         if (fs.existsSync(filepath)) {
-          self.emit('changed', filepath);
+          this.emit('changed', filepath);
         }
       });
     });
 
     next();
-  }, function () {
+  }, () => {
     // Return this instance of Gaze
     // delay before ready solves a lot of issues
-    setTimeout(function () {
-      self.emit('ready', self);
-      if (done) { done.call(self, null, self); }
+    setTimeout(() => {
+      this.emit('ready', this);
+      if (done) { done.call(this, null, this); }
     }, delay + 100);
   });
 };

--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -24,6 +24,7 @@ if (typeof setImmediate !== 'function') {
 
 // globals
 const delay = 10;
+function emptyFunction() {}
 
 // `Gaze` EventEmitter object to return in the callback
 function Gaze (patterns, opts, done) {
@@ -44,7 +45,7 @@ function Gaze (patterns, opts, done) {
   this.options = opts;
 
   // Default done callback
-  done = done || () => {};
+  done = done || emptyFunction;
 
   // Remember our watched dir:files
   this._watched = Object.create(null);
@@ -74,7 +75,7 @@ function Gaze (patterns, opts, done) {
   }
 
   // keep the process alive
-  this._keepalive = setInterval(() => {}, 200);
+  this._keepalive = setInterval(emptyFunction, 200);
 
   return this;
 }

--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -17,14 +17,14 @@ const globule = require('globule');
 const helper = require('./helper');
 
 // shim setImmediate for node v0.8
-const setImmediate = require('timers').setImmediate;
+let setImmediate = require('timers').setImmediate;
 if (typeof setImmediate !== 'function') {
   setImmediate = process.nextTick;
 }
 
 // globals
 const delay = 10;
-function emptyFunction() {}
+function emptyFunction () {}
 
 // `Gaze` EventEmitter object to return in the callback
 function Gaze (patterns, opts, done) {
@@ -92,7 +92,7 @@ module.exports.Gaze = Gaze;
 Gaze.prototype.emit = function () {
   let args = arguments;
 
-  const e = args[0];
+  let e = args[0];
   const filepath = args[1];
   let timeoutId;
 
@@ -104,7 +104,7 @@ Gaze.prototype.emit = function () {
 
   // Detect rename event, if added and previous deleted is in the cache
   if (e === 'added') {
-    Object.keys(this._cached).forEach( oldFile => {
+    Object.keys(this._cached).forEach(oldFile => {
       if (this._cached[oldFile].indexOf('deleted') !== -1) {
         args[0] = e = 'renamed';
         [].push.call(args, oldFile);
@@ -270,7 +270,7 @@ Gaze.prototype._addToWatched = function (files) {
 
   for (let i = 0; i < files.length; i++) {
     const file = files[i];
-    const filepath = path.resolve(this.options.cwd, file);
+    let filepath = path.resolve(this.options.cwd, file);
 
     let dirname = (helper.isDir(file)) ? filepath : path.dirname(filepath);
     dirname = helper.markDir(dirname);
@@ -289,7 +289,7 @@ Gaze.prototype._addToWatched = function (files) {
   dirs = helper.unique(dirs);
 
   for (let k = 0; k < dirs.length; k++) {
-    dirname = dirs[k];
+    const dirname = dirs[k];
     // add folders into the mix
     const readdir = fs.readdirSync(dirname);
     for (let j = 0; j < readdir.length; j++) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,7 +1,7 @@
-'use strict';
+const path = require('path');
+const helper = module.exports = {};
 
-var path = require('path');
-var helper = module.exports = {};
+function emptyFunction() {}
 
 // Returns boolean whether filepath is dir terminated
 helper.isDir = function isDir (dir) {
@@ -48,9 +48,9 @@ helper.unixifyPathSep = function unixifyPathSep (filepath) {
  * Available under MIT license <http://lodash.com/license>
  */
 helper.unique = function unique () {
-  var array = Array.prototype.concat.apply(Array.prototype, arguments);
-  var result = [];
-  for (var i = 0; i < array.length; i++) {
+  const array = Array.prototype.concat.apply(Array.prototype, arguments);
+  let result = [];
+  for (let i = 0; i < array.length; i++) {
     if (result.indexOf(array[i]) === -1) {
       result.push(array[i]);
     }
@@ -64,12 +64,12 @@ helper.unique = function unique () {
  */
 helper.forEachSeries = function forEachSeries (arr, iterator, callback) {
   if (!arr.length) { return callback(); }
-  var completed = 0;
-  var iterate = function () {
-    iterator(arr[completed], function (err) {
+  const completed = 0;
+  const iterate = () => {
+    iterator(arr[completed], err => {
       if (err) {
         callback(err);
-        callback = function () {};
+        callback = emptyFunction;
       } else {
         completed += 1;
         if (completed === arr.length) {

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const helper = module.exports = {};
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const helper = module.exports = {};
 
-function emptyFunction() {}
+function emptyFunction () {}
 
 // Returns boolean whether filepath is dir terminated
 helper.isDir = function isDir (dir) {
@@ -64,7 +64,7 @@ helper.unique = function unique () {
  */
 helper.forEachSeries = function forEachSeries (arr, iterator, callback) {
   if (!arr.length) { return callback(); }
-  const completed = 0;
+  let completed = 0;
   const iterate = () => {
     iterator(arr[completed], err => {
       if (err) {


### PR DESCRIPTION
I updated the code in the README to use const instead of var, and while I was at it also updated gaze itself to use const/let instead of var, and fat arrow functions (making `var self = this` unnecessary). I checked [node.green](https://node.green/) to see that my changes are supported by node 4.x. My CI is passing:

https://travis-ci.com/benatkin/gaze/builds

I saw that your travis CI build after you merged my last PR had an error. I wonder if switching to travis-ci.com which now supports open source would fix it. As part of migrating, it had me install Travis CI as a GitHub app, which may also get things running more smoothly.