### PR TITLE
Update node-globule to fix security audit issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "semistandard && grunt nodeunit -v"
   },
   "dependencies": {
-    "globule": "^1.0.0"
+    "globule": "^1.2.1"
   },
   "devDependencies": {
     "async": "^2.6.1",


### PR DESCRIPTION
Node-globule is out of date and contains security fixes to dependencies that can be found via `npm audit`