### PR TITLE
Remove unused setImmediate fallback

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -16,12 +16,6 @@ const path = require('path');
 const globule = require('globule');
 const helper = require('./helper');
 
-// shim setImmediate for node v0.8
-let setImmediate = require('timers').setImmediate;
-if (typeof setImmediate !== 'function') {
-  setImmediate = process.nextTick;
-}
-
 // globals
 const delay = 10;
 function emptyFunction () {}


### PR DESCRIPTION
Available since v0.9.1 per
https://nodejs.org/docs/latest-v4.x/api/globals.html#globals_clearimmediate_immediateobject