### PR TITLE
Remove redundant super call for setMaxListeners

### DIFF
--- a/lib/gaze.js
+++ b/lib/gaze.js
@@ -65,7 +65,6 @@ function Gaze (patterns, opts, done) {
   // Set maxListeners
   if (this.options.maxListeners != null) {
     this.setMaxListeners(this.options.maxListeners);
-    Gaze.super_.prototype.setMaxListeners(this.options.maxListeners);
     delete this.options.maxListeners;
   }
 


### PR DESCRIPTION
Given Gaze inherits EE, that means this.setMaxListeners()
was already calling EE.prototype.setMaxListeners.