### PR TITLE
Remove global grunt-cli install from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,5 @@ node_js:
   - '6'
   - '8'
   - '10'
-before_script:
-  - npm install -g grunt-cli
 git:
   depth: 9999999


### PR DESCRIPTION
"grunt-cli" is specified as a dev dependency in package.json.
All commands exported by (dev)dependencies are available via the
local node_modules/.bin directory, which is part of the PATH list
for the context used for "npm test".

Developers already experience this locally, when they run `npm install && npm test`
without installing Grunt globally. This has the added benefit of allowing you
to control which Grunt version is used for this project.

Removing the redundant entry from travis.yml makes sure that CI tests
use the same version as for local development, and prevents accidentally
using a newer version that might be incompatible, which would result in an
unrelated commit experiencing a build failure.

Documentation: https://docs.npmjs.com/misc/scripts#environment