### PR TITLE
Remove grunt-cli from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "async": "^2.6.1",
     "grunt": "^1.0.1",
     "grunt-benchmark": "^1.0.0",
-    "grunt-cli": "^1.2.0",
     "grunt-contrib-jshint": "^1.1.0",
     "grunt-contrib-nodeunit": "^2.0.0",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
As of Grunt 1.0, it is no longer needed to specify grunt-cli as it comes with Grunt by
default. Providing our own will get silently deduplicated by npm, unless the versions
diverge in which case we'd download both (and not sure which would "win").